### PR TITLE
change 'core' to 'cores' in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Sets coreadm defaults.
 include_recipe 'coreadm'
 
 coreadm 'do stuff' do
-  global_pattern '/var/core/global.core.%p'
-  per_process_pattern '/var/core/init.core.%p'
+  global_pattern '/var/cores/global.core.%p'
+  per_process_pattern '/var/cores/init.core.%p'
   disable :global
   enable :per_process, :global_setid, :per_process_setid
 end


### PR DESCRIPTION
Directory structure on SmartOS machines I have checked is `/var/cores`
